### PR TITLE
Updated for Spree 3.2.0.rc2 and Rails 5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,7 @@
 source 'https://rubygems.org'
 
-gem 'spree', github: 'spree/spree', branch: 'master'
+gem 'spree', github: 'spree/spree', branch: '3-2-stable'
+
+gem 'byebug'
 
 gemspec

--- a/app/controllers/concerns/spree/checkout_event_tracker.rb
+++ b/app/controllers/concerns/spree/checkout_event_tracker.rb
@@ -13,7 +13,7 @@ module Spree
     end
 
     def next_state
-      @next_state ||= checkout_state(request.url)
+      @next_state ||= checkout_state(request.path)
     end
 
     def previous_state

--- a/spec/controllers/spree/checkout_controlller_decorator_spec.rb
+++ b/spec/controllers/spree/checkout_controlller_decorator_spec.rb
@@ -24,7 +24,7 @@ describe Spree::CheckoutController do
   describe '#edit' do
 
     def send_request(state)
-      get :edit, state: state
+      get :edit, params: { state: state }
     end
 
     before do
@@ -82,7 +82,7 @@ describe Spree::CheckoutController do
   describe '#update' do
 
     def send_request
-      patch :update, state: order.state
+      patch :update, params: { state: order.state }
     end
 
     before do

--- a/spec/controllers/spree/orders_controller_decorator_spec.rb
+++ b/spec/controllers/spree/orders_controller_decorator_spec.rb
@@ -19,7 +19,7 @@ describe Spree::OrdersController do
   describe '#edit' do
 
     def send_request
-      get :edit, id: order.number
+      get :edit, params: { id: order.number }
     end
 
     describe 'when return to cart' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -94,4 +94,7 @@ RSpec.configure do |config|
   config.order = "random"
   config.include Spree::TestingSupport::ControllerRequests, type: :controller
   config.infer_spec_type_from_file_location!
+
+  config.include(Shoulda::Matchers::ActiveModel, type: :model)
+  config.include(Shoulda::Matchers::ActiveRecord, type: :model)
 end

--- a/spree_events_tracker.gemspec
+++ b/spree_events_tracker.gemspec
@@ -2,7 +2,7 @@
 Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
   s.name        = 'spree_events_tracker'
-  s.version     = '3.2.0.alpha'
+  s.version     = '3.2.0.rc2'
   s.summary     = 'Add gem summary here'
   s.description = 'Add (optional) gem description here'
   s.required_ruby_version = '>= 2.1.0'
@@ -17,11 +17,11 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.requirements << 'none'
 
-  spree_version = '~> 3.2.0.alpha'
+  spree_version = '~> 3.2.0.rc2'
 
   s.add_dependency 'spree_core', spree_version
   s.add_development_dependency 'capybara', '~> 2.6'
-  s.add_development_dependency 'coffee-rails', '~> 4.0.0'
+  s.add_development_dependency 'coffee-rails', '~> 4.2'
   s.add_development_dependency 'database_cleaner', '~> 1.5.0'
   s.add_development_dependency 'factory_girl', '~> 4.5'
   s.add_development_dependency 'ffaker', '~> 2.2.0'
@@ -29,8 +29,8 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rspec-rails', '~> 3.4'
   s.add_development_dependency 'sass-rails', '~> 5.0.0'
   s.add_development_dependency 'selenium-webdriver', '~> 2.53.0'
-  s.add_development_dependency 'shoulda-matchers', '~> 2.6.2'
-  s.add_development_dependency 'simplecov', '~> 0.11.0'
+  s.add_development_dependency 'shoulda-matchers', '~> 3.1.1'
+  s.add_development_dependency 'simplecov', '~> 0.13.0'
   s.add_development_dependency 'sqlite3', '~> 1.3.0'
   s.add_development_dependency 'spree_backend', spree_version
   s.add_development_dependency 'spree_frontend', spree_version


### PR DESCRIPTION
Fixed failing test rspec ./spec/controllers/spree/orders_controller_decorator_spec.rb:94 # Spree::OrdersController#edit when return to cart when return to cart from cart itself expect to not receive should not receive track_activity(*(any args)) 0 times
Changed request.url to request.path to avoid getting get_parameters in next_state comparison
-> next_state coming as “cart?id=” instead of “cart”
Fixed deprecation warning - use keyword syntax for get, put etc in controller tests
Fixed undefined methods for shoulda-matchers like validate_presence_of
Refer https://github.com/thoughtbot/shoulda-matchers/issues/951 and https://github.com/thoughtbot/shoulda-matchers#availability-of-matchers-in-various-example-groups