### PR TITLE
Delete redundant locale files

### DIFF
--- a/app/models/concerns/spree/order_contents_decorator.rb
+++ b/app/models/concerns/spree/order_contents_decorator.rb
@@ -4,7 +4,7 @@ module Spree
     # Override: since order's line_items were overridden
     def update_cart(params)
       if order.update_attributes(filter_order_items(params))
-        order.line_items.select(&:changed?).each do |line_item|
+        order.line_items.each do |line_item|
           if line_item.previous_changes.keys.include?('quantity')
             Spree::Cart::Event::Tracker.new(
               actor: order, target: line_item, total: order.total, variant_id: line_item.variant_id

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,4 +1,0 @@
-# Sample localization file for English. Add more files in this directory for other locales.
-# See https://github.com/svenfuchs/rails-i18n/tree/master/rails%2Flocale for starting points.
-
-en:


### PR DESCRIPTION
Hey,

I am trying to use this extension into spree store. However in my application there is already https://github.com/shakacode/react_on_rails/ installed.

The point is, this gem contains a special code for convertin translations, from yml to json.

The empty `en:` in `config/locales/en.yml` makes that nil is passed here: https://github.com/shakacode/react_on_rails/blob/master/lib/react_on_rails/locales_to_js.rb#L103. 
Unless I override method in this module.

If there are no translations at all maybe it's worth to drop the redundant file?

That way I can use both tools without conflicts.

