### PR TITLE
Cart Event Tracker Fixes

### DIFF
--- a/app/models/concerns/spree/order_contents_decorator.rb
+++ b/app/models/concerns/spree/order_contents_decorator.rb
@@ -4,7 +4,7 @@ module Spree
     # Override: since order's line_items were overridden
     def update_cart(params)
       if order.update_attributes(filter_order_items(params))
-        order.line_items.select(&:changed?).each do |line_item|
+        order.line_items.each do |line_item|
           if line_item.previous_changes.keys.include?('quantity')
             Spree::Cart::Event::Tracker.new(
               actor: order, target: line_item, total: order.total, variant_id: line_item.variant_id
@@ -22,6 +22,30 @@ module Spree
       else
         false
       end
+    end
+
+    def remove_line_item(line_item, options = {})
+      # In Cart Event Tracker, we use DirtyObject's previous_changes method.
+      # Following statement handles the case, when we delete a line_item from order's cart page (from back_end)
+      line_item.update(quantity: 0)
+      super
+    end
+
+    def remove_from_line_item(variant, quantity, options = {})
+      line_item = grab_line_item_by_variant(variant, true, options)
+      line_item.quantity -= quantity
+      line_item.target_shipment= options[:shipment]
+
+      if line_item.quantity.zero?
+        # In Cart Event Tracker, we use DirtyObject's previous_changes method.
+        # Following statement handles the case, when we delete a line_item from order's shipments page (from back_end)
+        line_item.update(quantity: 0)
+        order.line_items.destroy(line_item)
+      else
+        line_item.save!
+      end
+
+      line_item
     end
 
     private


### PR DESCRIPTION
# Issue
Cart Event Tracker
`update` and `remove` event not functioning properly

# Steps to replicate

- Create a new order (either from FE or BE) and add one line_item.

- Update the quantity of this line_item. The quantity of the line item will get updated but, a `CartEvent` object having `update` activity, will **not** be created.

- Now if we delete this line_item, a `CartEvent` object having `delete` activity, will **not** be created.
